### PR TITLE
fix #9: set scope `test` for dependency on jadice-format-ttf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
       <groupId>${docp.core.groupId}</groupId>
       <artifactId>jadice-format-ttf</artifactId>
       <version>${docp.core.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This will reduce the risk of dependency clashes for users of
documentplatform-standard14-fonts